### PR TITLE
Destroy frame

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,7 @@ GEM
     bootsnap (1.4.5)
       msgpack (~> 1.0)
     builder (3.2.4)
-    byebug (11.0.1)
+    byebug (11.1.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     crass (1.0.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,7 +214,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (1.6.0)
+    unicode-display_width (1.6.1)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  helper_method :current_user, :logged_in_by_user?
+  helper_method :current_user, :current_planner, :current_client, :logged_in_by_user?
 
   def current_user
     @current_user ||= User.find_by(id: session[:user_id])

--- a/app/controllers/available_frames_controller.rb
+++ b/app/controllers/available_frames_controller.rb
@@ -26,8 +26,8 @@ class AvailableFramesController < ApplicationController
       flash[:success] = ["予約枠を削除しました"]
     rescue ActiveRecord::RecordNotFound
       flash[:danger] = ["存在しない予約枠です"]
-    rescue ActiveRecord::RecordNotDestroyed
-      flash[:danger] = available_frame.errors.full_messages
+    rescue ActiveRecord::RecordNotDestroyed => err
+      flash[:danger] = err.record.errors.full_messages
     end
     redirect_to action: :index
   end

--- a/app/controllers/available_frames_controller.rb
+++ b/app/controllers/available_frames_controller.rb
@@ -12,7 +12,7 @@ class AvailableFramesController < ApplicationController
   def create
     available_frame = current_planner.available_frames.build(available_frame_params)
     if available_frame.save
-      flash[:success] = "予約枠を追加しました"
+      flash[:success] = ["予約枠を追加しました"]
     else
       flash[:danger] = available_frame.errors.full_messages
     end
@@ -22,10 +22,13 @@ class AvailableFramesController < ApplicationController
   def destroy
     available_frame = current_planner.available_frames.find_by(id: params[:id])
     if available_frame
-      available_frame.destroy
-      flash[:success] = "予約枠を削除しました"
+      if available_frame.destroy
+        flash[:success] = ["予約枠を削除しました"]
+      else
+        flash[:danger] = available_frame.errors.full_messages
+      end
     else
-      flash[:danger] = "存在しない予約枠です"
+      flash[:danger] = ["存在しない予約枠です"]
     end
     redirect_to action: :index
   end

--- a/app/controllers/available_frames_controller.rb
+++ b/app/controllers/available_frames_controller.rb
@@ -6,13 +6,11 @@ class AvailableFramesController < ApplicationController
   def index
     @from = (params[:from]&.in_time_zone || Time.current).change(hour: 0, min: 0, sec: 0)
     to = @from.since(7.days)
-    planner = current_planner
-    @available_frames = planner.available_frames.where(scheduled_time: (@from)..(to))
+    @available_frames = current_planner.available_frames.where(scheduled_time: (@from)..(to))
   end
 
   def create
-    planner = current_planner
-    available_frame = planner.available_frames.build(available_frame_params)
+    available_frame = current_planner.available_frames.build(available_frame_params)
     if available_frame.save
       flash[:success] = "予約枠を追加しました"
       redirect_to action: :index
@@ -23,6 +21,9 @@ class AvailableFramesController < ApplicationController
   end
 
   def destroy
+    available_frame = current_planner.available_frames.find_by(id: params[:id])
+    available_frame.destroy
+    redirect_to action: :index
   end
 
   private

--- a/app/controllers/available_frames_controller.rb
+++ b/app/controllers/available_frames_controller.rb
@@ -20,15 +20,14 @@ class AvailableFramesController < ApplicationController
   end
 
   def destroy
-    available_frame = current_planner.available_frames.find_by(id: params[:id])
-    if available_frame
-      if available_frame.destroy
-        flash[:success] = ["予約枠を削除しました"]
-      else
-        flash[:danger] = available_frame.errors.full_messages
-      end
-    else
+    begin
+      available_frame = current_planner.available_frames.find(id: params[:id])
+      available_frame.destroy!
+      flash[:success] = ["予約枠を削除しました"]
+    rescue ActiveRecord::RecordNotFound
       flash[:danger] = ["存在しない予約枠です"]
+    rescue ActiveRecord::RecordNotDestroyed
+      flash[:danger] = available_frame.errors.full_messages
     end
     redirect_to action: :index
   end

--- a/app/controllers/available_frames_controller.rb
+++ b/app/controllers/available_frames_controller.rb
@@ -22,7 +22,12 @@ class AvailableFramesController < ApplicationController
 
   def destroy
     available_frame = current_planner.available_frames.find_by(id: params[:id])
-    available_frame.destroy
+    if available_frame
+      available_frame.destroy
+      flash[:success] = "予約枠を削除しました"
+    else
+      flash[:danger] = "存在しない予約枠です"
+    end
     redirect_to action: :index
   end
 

--- a/app/controllers/available_frames_controller.rb
+++ b/app/controllers/available_frames_controller.rb
@@ -21,7 +21,7 @@ class AvailableFramesController < ApplicationController
 
   def destroy
     begin
-      available_frame = current_planner.available_frames.find(id: params[:id])
+      available_frame = current_planner.available_frames.find(params[:id])
       available_frame.destroy!
       flash[:success] = ["予約枠を削除しました"]
     rescue ActiveRecord::RecordNotFound

--- a/app/javascript/packs/available_frames/index.js
+++ b/app/javascript/packs/available_frames/index.js
@@ -1,16 +1,14 @@
 const setModalContent = (available, datetime) => {
     const idName = available ? 'inactivate-frame-confirm-text' : 'activate-frame-confirm-text'
     let paragTag = document.getElementById(idName)
-    console.log(paragTag)
 
     const performText = !available ? "有効" : "無効"
-
     paragTag.innerText = `${datetime}の予約枠を${performText}にしますか?`
 }
 
 const setDatetimeToTextField = datetime => {
-     let textField = document.getElementById("available_frame-scheduled_time")
-     textField.value = datetime
+    let textField = document.getElementById("available_frame-scheduled_time")
+    textField.value = datetime
 }
 
 const setDestroyHref = (path) => {

--- a/app/javascript/packs/available_frames/index.js
+++ b/app/javascript/packs/available_frames/index.js
@@ -1,5 +1,5 @@
 const setModalContent = (available, datetime) => {
-    const idName = undefined !== avilalble ? 'inactivate-frame-confirm-text' : 'activate-frame-confirm-text'
+    const idName = available ? 'inactivate-frame-confirm-text' : 'activate-frame-confirm-text'
     let paragTag = document.getElementById(idName)
     console.log(paragTag)
 
@@ -13,9 +13,10 @@ const setDatetimeToTextField = datetime => {
      textField.value = datetime
 }
 
-// const setDestroyHref = () => {
-//     setHref =
-// }
+const setDestroyHref = (path) => {
+    let destroyLink = document.getElementById("destroy-frame-link")
+    destroyLink.setAttribute("href", path)
+}
 
 window.onload = () => {
     const triggerButtons = document.getElementsByClassName('available_frame-trigger-btn')
@@ -25,8 +26,12 @@ window.onload = () => {
             console.log(btn.dataset)
             const available = btn.dataset.path !== undefined
             const datetime = btn.dataset.datetime
-            setModalContent(available, datetime)
+            const path = btn.dataset.path
+            setModalContent(available, datetime, path)
             setDatetimeToTextField(datetime)
+            if (available) {
+                setDestroyHref(path)
+            }
         }
     })
 }

--- a/app/javascript/packs/available_frames/index.js
+++ b/app/javascript/packs/available_frames/index.js
@@ -1,23 +1,31 @@
-const setModalContent = (isAvailable, datetime) => {
-    let paragTag = document.getElementById('available_frame-request-confirm-text')
+const setModalContent = (available, datetime) => {
+    const idName = undefined !== avilalble ? 'inactivate-frame-confirm-text' : 'activate-frame-confirm-text'
+    let paragTag = document.getElementById(idName)
+    console.log(paragTag)
 
-    const performText = !isAvailable ? "有効" : "無効"
+    const performText = !available ? "有効" : "無効"
+
     paragTag.innerText = `${datetime}の予約枠を${performText}にしますか?`
 }
 
-const setDatetimeToTextField = (datetime) => {
+const setDatetimeToTextField = datetime => {
      let textField = document.getElementById("available_frame-scheduled_time")
      textField.value = datetime
 }
+
+// const setDestroyHref = () => {
+//     setHref =
+// }
 
 window.onload = () => {
     const triggerButtons = document.getElementsByClassName('available_frame-trigger-btn')
 
     Array.from(triggerButtons).forEach( btn => {
         btn.onclick = () => {
-            const isAvailable = btn.dataset.is_available === "true"
+            console.log(btn.dataset)
+            const available = btn.dataset.path !== undefined
             const datetime = btn.dataset.datetime
-            setModalContent(isAvailable, datetime)
+            setModalContent(available, datetime)
             setDatetimeToTextField(datetime)
         }
     })

--- a/app/javascript/packs/available_frames/index.js
+++ b/app/javascript/packs/available_frames/index.js
@@ -25,10 +25,10 @@ window.onload = () => {
 
     Array.from(triggerButtons).forEach( btn => {
         btn.onclick = () => {
-            console.log(btn.dataset)
             const available = btn.dataset.path !== undefined
             const datetime = btn.dataset.datetime
             const path = btn.dataset.path
+
             setModalContent(available, datetime, path)
             setDatetimeToTextField(datetime)
             if (available) {

--- a/app/javascript/packs/available_frames/index.js
+++ b/app/javascript/packs/available_frames/index.js
@@ -1,9 +1,13 @@
+import moment from "moment"
+
 const setModalContent = (available, datetime) => {
     const idName = available ? 'inactivate-frame-confirm-text' : 'activate-frame-confirm-text'
     let paragTag = document.getElementById(idName)
 
+    // example of datetime -> "2020-01-23T10:30:00.000+09:00"
+    const formattedDate = moment(datetime, "YYYY-MM-DDThh:mm:ss.000+09:00").format("YYYY年MM月DD日 hh時mm分")
     const performText = !available ? "有効" : "無効"
-    paragTag.innerText = `${datetime}の予約枠を${performText}にしますか?`
+    paragTag.innerText = `${formattedDate}の予約枠を${performText}にしますか?`
 }
 
 const setDatetimeToTextField = datetime => {

--- a/app/models/available_frame.rb
+++ b/app/models/available_frame.rb
@@ -3,7 +3,7 @@
 class AvailableFrame < ApplicationRecord
   before_destroy do
     if reservation
-      errors.add(:this, "is already reserved")
+      errors.add(:this, "is already reserved by client")
       throw :abort
     end
   end

--- a/app/models/available_frame.rb
+++ b/app/models/available_frame.rb
@@ -1,8 +1,15 @@
 # frozen_string_literal: true
 
 class AvailableFrame < ApplicationRecord
+  before_destroy do
+    if reservation
+      errors.add(:this, "is already reserved")
+      throw :abort
+    end
+  end
+
   belongs_to :planner
-  has_one :reservation
+  has_one :reservation, dependent: :destroy
 
   validates :planner, presence: true
   validates :scheduled_time, presence: true

--- a/app/models/available_frame.rb
+++ b/app/models/available_frame.rb
@@ -1,12 +1,7 @@
 # frozen_string_literal: true
 
 class AvailableFrame < ApplicationRecord
-  before_destroy do
-    if reservation
-      errors.add(:this, "is already reserved by client")
-      throw :abort
-    end
-  end
+  before_destroy :prevent_destroy_if_reservation_exist
 
   belongs_to :planner
   has_one :reservation, dependent: :destroy
@@ -15,4 +10,12 @@ class AvailableFrame < ApplicationRecord
   validates :scheduled_time, presence: true
   validates :scheduled_time, scheduled_time: true, if: :scheduled_time
   validates :planner_id, uniqueness: { scope: [:scheduled_time] }
+
+  private
+    def prevent_destroy_if_reservation_exist
+      if reservation
+        errors.add(:this, "is already reserved by client")
+        throw :abort
+      end
+    end
 end

--- a/app/models/frame_table.rb
+++ b/app/models/frame_table.rb
@@ -16,14 +16,14 @@ class FrameTable
     # 予約可能枠を当てはめる必要があるため,いきなり二次元配列にしない(二次元配列にすると探索が面倒)
     base_cells = FrameTable.start_times.flat_map do |start_time|
       FrameTable.date_range(start_day).map do |day|
-        OpenStruct.new(datetime: start_time.on(day), time: start_time, is_available: false)
+        OpenStruct.new(datetime: start_time.on(day), time: start_time, id: nil)
       end
     end
 
     # plannerが設定した予約枠を入れ込む
     frames.each do |frame|
       cell = base_cells.find { |element| frame.scheduled_time == element.datetime }
-      cell.is_available = true
+      cell.id = frame.id
     end
 
     # timeでグループ化し，valuesをとることで二次元配列にする

--- a/app/models/frame_table_spec.rb
+++ b/app/models/frame_table_spec.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require "rails_helper"
-
-RSpec.describe FrameTable, type: :model do
-  describe "to_matrix" do
-    # 何をすればいいんだ？
-  end
-end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -10,7 +10,7 @@ class Reservation < ApplicationRecord
 
   validates :client, presence: true
   validates :available_frame, presence: true, uniqueness: true
-  validate :other_reservation_exists_in_same_time, if: [:client, :available_frame]
+  validate :other_reservation_exists_in_same_time, if: [:client, :available_frame], on: :create
 
   private
     def other_reservation_exists_in_same_time

--- a/app/views/available_frames/index.html.slim
+++ b/app/views/available_frames/index.html.slim
@@ -61,4 +61,4 @@
           .modal-footer
             button.btn.btn-secondary type="button" data-dismiss="modal"
               | キャンセル
-            = link_to '削除', class: 'btn btn-primary', method: :delete
+            = link_to '削除', id: "destroy-frame-link", class: 'btn btn-primary', method: :delete

--- a/app/views/available_frames/index.html.slim
+++ b/app/views/available_frames/index.html.slim
@@ -17,7 +17,9 @@
               th
                 .text-center = range
                 - frames.each do |frame|
-                  / 予約可能枠が既に存在するセルは緑色にする(bg-success)
+                  / frame.idが存在する = 予約枠が既にセットされている．
+                  / frame削除用のpathを精製する必要があり，それにframe.idを用いている(L31のdata-pathとして渡している)
+                  / jsで削除確認用のモーダル内ボタンのhrefにしている
 
                   td class="#{frame.id ? "bg-success" : nil}"
                     .text-center.frame-cell = frame.id ? "○" : "×"

--- a/app/views/available_frames/index.html.slim
+++ b/app/views/available_frames/index.html.slim
@@ -40,7 +40,7 @@
           span aria-hidden="true"
             | &times;
       .modal-body
-        p#available_frame-request-confirm-text
+        p#activate-frame-confirm-text
         = form_with(model: AvailableFrame.new, local: true, url: planner_available_frames_path) do |f|
           = f.text_field :scheduled_time, id: "available_frame-scheduled_time", class: "d-none"
           .modal-footer
@@ -57,8 +57,8 @@
           span aria-hidden="true"
             | &times;
       .modal-body
-        p#available_frame-request-confirm-text
+        p#inactivate-frame-confirm-text
           .modal-footer
             button.btn.btn-secondary type="button" data-dismiss="modal"
               | キャンセル
-            = link_to ''
+            = link_to '削除', class: 'btn btn-primary', method: :delete

--- a/app/views/available_frames/index.html.slim
+++ b/app/views/available_frames/index.html.slim
@@ -17,6 +17,8 @@
               th
                 .text-center = range
                 - frames.each do |frame|
+                  / 予約可能枠が既に存在するセルは緑色にする(bg-success)
+
                   td class="#{frame.id ? "bg-success" : nil}"
                     .text-center.frame-cell = frame.id ? "○" : "×"
                     .text-center

--- a/app/views/available_frames/index.html.slim
+++ b/app/views/available_frames/index.html.slim
@@ -61,4 +61,4 @@
           .modal-footer
             button.btn.btn-secondary type="button" data-dismiss="modal"
               | キャンセル
-            = link_to '削除', id: "destroy-frame-link", class: 'btn btn-primary', method: :delete
+            = link_to '削除', "", id: "destroy-frame-link", class: 'btn btn-primary', method: :delete

--- a/app/views/available_frames/index.html.slim
+++ b/app/views/available_frames/index.html.slim
@@ -17,15 +17,21 @@
               th
                 .text-center = range
                 - frames.each do |frame|
-                  td class="#{frame.is_available ? "bg-success" : nil}"
-                    .text-center.frame-cell = frame.is_available ? "○" : "×"
+                  td class="#{frame.id ? "bg-success" : nil}"
+                    .text-center.frame-cell = frame.id ? "○" : "×"
                     .text-center
-                      = button_tag frame.is_available ? "無効にする" : "有効にする",
-                          class: "available_frame-trigger-btn btn btn-light btn-sm",
-                          type: "button",
-                          data: { toggle: "modal", target: "#confirmModal", datetime: frame.datetime, is_available: frame.is_available }
+                      - if frame.id
+                        = button_tag "無効にする",
+                            class: "available_frame-trigger-btn btn btn-light btn-sm",
+                            type: "button",
+                            data: { toggle: "modal", target: "#confirmInactivateModal", datetime: frame.datetime, path: planner_available_frame_path(current_planner.id, frame.id)}
+                      - else
+                        = button_tag "有効にする",
+                            class: "available_frame-trigger-btn btn btn-light btn-sm",
+                            type: "button",
+                            data: { toggle: "modal", target: "#confirmActivateModal", datetime: frame.datetime }
 
-#confirmModal.modal.fade tabindex=-1
+#confirmActivateModal.modal.fade tabindex=-1
   .modal-dialog role="document"
     .modal-content
       .modal-header
@@ -41,3 +47,18 @@
             button.btn.btn-secondary type="button" data-dismiss="modal"
               | キャンセル
             = f.submit "OK", class: "btn btn-primary"
+
+#confirmInactivateModal.modal.fade tabindex=-1
+  .modal-dialog role="document"
+    .modal-content
+      .modal-header
+        h5.modal-title 確認
+        button.close data-dismiss="modal" aria-label='キャンセル'
+          span aria-hidden="true"
+            | &times;
+      .modal-body
+        p#available_frame-request-confirm-text
+          .modal-footer
+            button.btn.btn-secondary type="button" data-dismiss="modal"
+              | キャンセル
+            = link_to ''

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,7 +2,7 @@
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
- SET NAMES utf8 ;
+/*!40101 SET NAMES utf8 */;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
@@ -11,7 +11,7 @@
 /*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
 DROP TABLE IF EXISTS `ar_internal_metadata`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
- SET character_set_client = utf8mb4 ;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `ar_internal_metadata` (
   `key` varchar(255) NOT NULL,
   `value` varchar(255) DEFAULT NULL,
@@ -22,7 +22,7 @@ CREATE TABLE `ar_internal_metadata` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `available_frames`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
- SET character_set_client = utf8mb4 ;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `available_frames` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `scheduled_time` datetime NOT NULL COMMENT '予約可能な日時(開始時間)',
@@ -37,7 +37,7 @@ CREATE TABLE `available_frames` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `reservations`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
- SET character_set_client = utf8mb4 ;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `reservations` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `scheduled_time` datetime NOT NULL COMMENT '予約枠の日時(開始時間)',
@@ -55,7 +55,7 @@ CREATE TABLE `reservations` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `schema_migrations`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
- SET character_set_client = utf8mb4 ;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `schema_migrations` (
   `version` varchar(255) NOT NULL,
   PRIMARY KEY (`version`)
@@ -63,7 +63,7 @@ CREATE TABLE `schema_migrations` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `users`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
- SET character_set_client = utf8mb4 ;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `users` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `name` varchar(50) NOT NULL,

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,7 +2,7 @@
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8 */;
+/*!40101 SET NAMES utf8mb4 */;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
@@ -13,12 +13,12 @@ DROP TABLE IF EXISTS `ar_internal_metadata`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `ar_internal_metadata` (
-  `key` varchar(255) NOT NULL,
+  `key` varchar(255) CHARACTER SET utf8 NOT NULL,
   `value` varchar(255) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`key`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `available_frames`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -33,7 +33,7 @@ CREATE TABLE `available_frames` (
   UNIQUE KEY `index_available_frames_on_planner_id_and_scheduled_time` (`planner_id`,`scheduled_time`),
   KEY `index_available_frames_on_planner_id` (`planner_id`),
   CONSTRAINT `fk_rails_62edaf47d6` FOREIGN KEY (`planner_id`) REFERENCES `users` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `reservations`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -51,15 +51,15 @@ CREATE TABLE `reservations` (
   KEY `index_reservations_on_planner_id` (`planner_id`),
   CONSTRAINT `fk_rails_2e7a5301f5` FOREIGN KEY (`planner_id`) REFERENCES `users` (`id`),
   CONSTRAINT `fk_rails_9c963d6879` FOREIGN KEY (`client_id`) REFERENCES `users` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `schema_migrations`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `schema_migrations` (
-  `version` varchar(255) NOT NULL,
+  `version` varchar(255) CHARACTER SET utf8 NOT NULL,
   PRIMARY KEY (`version`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `users`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -75,7 +75,7 @@ CREATE TABLE `users` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_users_on_email` (`email`),
   KEY `index_users_on_user_type` (`user_type`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,7 +2,7 @@
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8 */;
+ SET NAMES utf8 ;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
@@ -11,7 +11,7 @@
 /*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
 DROP TABLE IF EXISTS `ar_internal_metadata`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `ar_internal_metadata` (
   `key` varchar(255) NOT NULL,
   `value` varchar(255) DEFAULT NULL,
@@ -22,7 +22,7 @@ CREATE TABLE `ar_internal_metadata` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `available_frames`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `available_frames` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `scheduled_time` datetime NOT NULL COMMENT '予約可能な日時(開始時間)',
@@ -37,7 +37,7 @@ CREATE TABLE `available_frames` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `reservations`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `reservations` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `scheduled_time` datetime NOT NULL COMMENT '予約枠の日時(開始時間)',
@@ -55,7 +55,7 @@ CREATE TABLE `reservations` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `schema_migrations`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `schema_migrations` (
   `version` varchar(255) NOT NULL,
   PRIMARY KEY (`version`)
@@ -63,7 +63,7 @@ CREATE TABLE `schema_migrations` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `users`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `users` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `name` varchar(50) NOT NULL,

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -47,9 +47,8 @@ CREATE TABLE `reservations` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_reservations_on_available_frame_id` (`available_frame_id`),
   KEY `index_reservations_on_client_id` (`client_id`),
-  KEY `index_reservations_on_planner_id` (`planner_id`),
-  CONSTRAINT `fk_rails_2e7a5301f5` FOREIGN KEY (`planner_id`) REFERENCES `users` (`id`),
-  CONSTRAINT `fk_rails_9c963d6879` FOREIGN KEY (`client_id`) REFERENCES `users` (`id`)
+  CONSTRAINT `fk_rails_9c963d6879` FOREIGN KEY (`client_id`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_rails_a1172fd802` FOREIGN KEY (`available_frame_id`) REFERENCES `available_frames` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `schema_migrations`;

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "bootstrap": "^4.4.1",
     "bootswatch": "^4.4.1",
     "jquery": "^3.4.1",
+    "moment": "^2.24.0",
     "popper.js": "^1.16.0",
     "rails-ujs": "^5.2.4-1"
   },

--- a/spec/models/frame_table_spec.rb
+++ b/spec/models/frame_table_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe FrameTable, type: :model do
   let(:planner) { build(:planner) }
   let(:start_day) { Time.current.to_date }
   let(:frames) {
-    [ build(:available_frame, planner: planner, scheduled_time: "2019-12-19 13:00:00".in_time_zone),
-      build(:available_frame, planner: planner, scheduled_time: "2019-12-19 13:30:00".in_time_zone),
-      build(:available_frame, planner: planner, scheduled_time: "2019-12-20 11:30:00".in_time_zone),
+    [ create(:available_frame, planner: planner, scheduled_time: "2019-12-19 13:00:00".in_time_zone),
+      create(:available_frame, planner: planner, scheduled_time: "2019-12-19 13:30:00".in_time_zone),
+      create(:available_frame, planner: planner, scheduled_time: "2019-12-20 11:30:00".in_time_zone),
     ]
   }
 
@@ -28,9 +28,9 @@ RSpec.describe FrameTable, type: :model do
     # 予約枠は正しく入っているか
     context "confirm available_frame at correct block" do
       subject { target.to_matrix }
-      it { expect(subject[6][1].is_available).to eq(true) }
-      it { expect(subject[3][2].is_available).to eq(true) }
-      it { expect(subject[7][1].is_available).to eq(true) }
+      it { expect(subject[6][1].id).to be_present }
+      it { expect(subject[3][2].id).to be_present }
+      it { expect(subject[7][1].id).to be_present }
     end
   end
 end

--- a/spec/requests/available_frames_controller_spec.rb
+++ b/spec/requests/available_frames_controller_spec.rb
@@ -49,4 +49,12 @@ RSpec.describe AvailableFramesController, type: :request do
       end
     end
   end
+
+  describe "DELETE /planners/:planner_id/available_frames/:id" do
+    context "valid available_frame id" do
+    end
+
+    context "unknown available_frame id" do
+    end
+  end
 end

--- a/spec/requests/available_frames_controller_spec.rb
+++ b/spec/requests/available_frames_controller_spec.rb
@@ -61,6 +61,17 @@ RSpec.describe AvailableFramesController, type: :request do
       end
     end
 
+    context "available_frame which fail destroy validation" do
+      let(:id) { planner.available_frames.first.id }
+      let(:client) { create(:client) }
+      before { create(:reservation, client: client, available_frame_id: id) }
+
+      it do
+        is_expected.to redirect_to planner_available_frames_path(planner)
+        expect(flash[:danger]).to eq(["This is already reserved by client"])
+      end
+    end
+
     context "unknown available_frame id" do
       let(:id) { AvailableFrame.last.id + 100 }
       it do

--- a/spec/requests/available_frames_controller_spec.rb
+++ b/spec/requests/available_frames_controller_spec.rb
@@ -3,12 +3,14 @@
 require "rails_helper"
 
 RSpec.describe AvailableFramesController, type: :request do
-  let(:planner) { create(:planner) }
-  let(:planner_id) { planner.id }
+  include_context "travel_to_20191218_noon"
 
-  around do |e|
-    travel_to("2019-12-18 12:00:00") { e.run }
+  let(:planner) do
+    create(:planner) do |planner|
+      planner.available_frames.create(scheduled_time: "2019-12-18 13:00:00")
+    end
   end
+  let(:planner_id) { planner.id }
 
   before do
     allow_any_instance_of(ActionDispatch::Request).to receive(:session).and_return({ user_id: planner_id })
@@ -51,7 +53,9 @@ RSpec.describe AvailableFramesController, type: :request do
   end
 
   describe "DELETE /planners/:planner_id/available_frames/:id" do
+
     context "valid available_frame id" do
+      let(:id) { planner.available_frames.first.id }
       it do
         is_expected.to redirect_to planner_available_frames_path(planner)
         expect(flash[:success]).to eq("予約枠を削除しました")
@@ -59,6 +63,7 @@ RSpec.describe AvailableFramesController, type: :request do
     end
 
     context "unknown available_frame id" do
+      let(:id) { 10000 }
       it do
         is_expected.to redirect_to planner_available_frames_path(planner)
         expect(flash[:danger]).to eq("存在しない予約枠です")

--- a/spec/requests/available_frames_controller_spec.rb
+++ b/spec/requests/available_frames_controller_spec.rb
@@ -52,9 +52,17 @@ RSpec.describe AvailableFramesController, type: :request do
 
   describe "DELETE /planners/:planner_id/available_frames/:id" do
     context "valid available_frame id" do
+      it do
+        is_expected.to redirect_to planner_available_frames_path(planner)
+        expect(flash[:success]).to eq("予約枠を削除しました")
+      end
     end
 
     context "unknown available_frame id" do
+      it do
+        is_expected.to redirect_to planner_available_frames_path(planner)
+        expect(flash[:danger]).to eq("存在しない予約枠です")
+      end
     end
   end
 end

--- a/spec/requests/available_frames_controller_spec.rb
+++ b/spec/requests/available_frames_controller_spec.rb
@@ -53,7 +53,6 @@ RSpec.describe AvailableFramesController, type: :request do
   end
 
   describe "DELETE /planners/:planner_id/available_frames/:id" do
-
     context "valid available_frame id" do
       let(:id) { planner.available_frames.first.id }
       it do

--- a/spec/requests/available_frames_controller_spec.rb
+++ b/spec/requests/available_frames_controller_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe AvailableFramesController, type: :request do
     end
 
     context "unknown available_frame id" do
-      let(:id) { 10000 }
+      let(:id) { AvailableFrame.last.id + 100 }
       it do
         is_expected.to redirect_to planner_available_frames_path(planner)
         expect(flash[:danger]).to eq("存在しない予約枠です")

--- a/spec/requests/available_frames_controller_spec.rb
+++ b/spec/requests/available_frames_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe AvailableFramesController, type: :request do
 
       it do
         is_expected.to redirect_to planner_available_frames_path(planner)
-        expect(flash[:success]).to eq("予約枠を追加しました")
+        expect(flash[:success]).to eq(["予約枠を追加しました"])
       end
     end
 
@@ -57,7 +57,7 @@ RSpec.describe AvailableFramesController, type: :request do
       let(:id) { planner.available_frames.first.id }
       it do
         is_expected.to redirect_to planner_available_frames_path(planner)
-        expect(flash[:success]).to eq("予約枠を削除しました")
+        expect(flash[:success]).to eq(["予約枠を削除しました"])
       end
     end
 
@@ -65,7 +65,7 @@ RSpec.describe AvailableFramesController, type: :request do
       let(:id) { AvailableFrame.last.id + 100 }
       it do
         is_expected.to redirect_to planner_available_frames_path(planner)
-        expect(flash[:danger]).to eq("存在しない予約枠です")
+        expect(flash[:danger]).to eq(["存在しない予約枠です"])
       end
     end
   end

--- a/spec/support/shared_contexts/travel_to_20191218_noon.rb
+++ b/spec/support/shared_contexts/travel_to_20191218_noon.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "travel_to_20191218_noon" do
+  around do |e|
+    travel_to("2019-12-18 12:00:00") { e.run }
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -4291,6 +4291,11 @@ mixin-deep@^1.2.0:
   dependencies:
     minimist "0.0.8"
 
+moment@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
## 要約
- available_frames_controller.destroyの実装
- ↑のspec実装
- 予約枠削除のためのlinkを追加
- frame_tableの要素が持つ属性の修正
    - `is_available` -> `id` に変更
- 予約確認モーダルに表示している時間をフォーマット
- frame_table_specの修正

close #40 