### PR TITLE
add spec for size of frame_table.to_matrix

### DIFF
--- a/spec/models/frame_table_spec.rb
+++ b/spec/models/frame_table_spec.rb
@@ -3,9 +3,7 @@
 require "rails_helper"
 
 RSpec.describe FrameTable, type: :model do
-  around do |e|
-    travel_to("2019-12-18 12:00:00") { e.run }
-  end
+  include_context "travel_to_20191218_noon"
 
   let(:planner) { build(:planner) }
   let(:start_day) { Time.current.to_date }
@@ -18,10 +16,10 @@ RSpec.describe FrameTable, type: :model do
 
   let(:target) { FrameTable.new(frames, start_day) }
 
-  describe "self.generate_matrix" do
+  describe "self.to_matrix" do
     context "no frames on sunday" do
       let(:sundays) { target.to_matrix.transpose[4] }
-      subject { sundays.none? { |item| item.is_available } }
+      subject { sundays.none? { |item| item.id } }
       it { expect(subject).to eq(true) }
     end
 
@@ -31,6 +29,16 @@ RSpec.describe FrameTable, type: :model do
       it { expect(subject[6][1].id).to be_present }
       it { expect(subject[3][2].id).to be_present }
       it { expect(subject[7][1].id).to be_present }
+    end
+
+    it { expect(target.to_matrix.size).to eq(16) }
+    it "is expected to 7 columns" do
+      binding.pry
+      expect { target.to_matrix.map { |item| p item.size; item.size == 7 }.all? }.to eq(true)
+
+      # ERR: targetのinitializeでframesとstart_dayが渡されていない扱いになる
+      # subject { target.to_matrix.map { |item| p item.size; item.size == 7 }.all? }
+      # is_expected.to eq(true)
     end
   end
 end


### PR DESCRIPTION
## 概要
- frame_table_specでto_matrixが返す二次元配列のサイズ（行と列）のサイズのテストを追加
- ちょっとした修正

- itの中でsubject定義はダメそう

close #37 